### PR TITLE
electron-prebuilt moved to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/farnabaz/darling#readme",
   "devDependencies": {
+    "electron-prebuilt": "^1.2.8",
     "babel-core": "^6.13.1",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.13.1",
@@ -39,7 +40,6 @@
     "webpack-target-electron-renderer": "^0.4.0"
   },
   "dependencies": {
-    "electron-prebuilt": "^1.2.8",
     "hexo": "^3.2.2",
     "react": "^15.3.0",
     "react-dom": "^15.3.0",


### PR DESCRIPTION
electron-prebuilt is a develop dependency and does not need to be in dist dependencies.
